### PR TITLE
Add *.csv to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -191,5 +191,7 @@ Session.vim
 # auto-generated tag files
 tags
 
+#csv files to prevent large commits
+*.csv
 
 # End of https://www.gitignore.io/api/vim,linux,emacs,python


### PR DESCRIPTION
Soooo adding that huge csv file would make GitHub think that I added several hundred thousand lines of code. Now I'm not an expert, but I think that this might not be a best practice. Also, through some [research](https://blog.patricktriest.com/analyzing-cryptocurrencies-python/), I think that Python has a much better way for us to get this data without needing to pull it from a CSV, and it is always up to date. 

I think that if we want to have CSV files on the repo, we should zip them up so they don't appear as these massive commits. 

Let me know what you think