### PR TITLE
Add csv consolidation script and tests

### DIFF
--- a/csv_consolidator.py
+++ b/csv_consolidator.py
@@ -1,0 +1,61 @@
+import sys
+import re
+
+def consolidateCSV(csvPath, outputFile):
+    """ Takes the csv file located at csvPath that was downloaded from 
+    https://api.bitcoincharts.com/v1/csv/ and consolidates the duplicate 
+    timestamps into one entry with the price and volume values being the 
+    average of all entries with that timestamp. It is required that the 
+    csv file located at csvPath has the form: 
+        [timestamp], [price], [volume]
+    """
+    print("beginning consolidation of " + csvPath + " to output file " + \
+          outputFile + "...\nthis may take a while...\n")
+
+    with open(csvPath) as input:
+        firstLine = input.readline().split(",")
+        currentTimeStamp = firstLine[0]
+        price_sum = float(firstLine[1])
+        volume_sum = float(firstLine[2])
+        with open(outputFile, "w") as output:
+            n_lines_since_reset = 1
+            for i in input:
+                current_line = i.split(",")
+                if current_line[0] != currentTimeStamp:
+                    output.write(currentTimeStamp + "," \
+                                 + str(price_sum / n_lines_since_reset) + "," \
+                                 + str(volume_sum / n_lines_since_reset) + "\n")
+                    currentTimeStamp = current_line[0]
+                    price_sum = float(current_line[1])
+                    volume_sum = float(current_line[2])
+                    n_lines_since_reset = 1
+                else:
+                    price_sum += float(current_line[1])
+                    volume_sum += float(current_line[2])
+                    n_lines_since_reset += 1
+            output.write(currentTimeStamp + "," \
+                         + str(price_sum / n_lines_since_reset) + "," \
+                         + str(volume_sum / n_lines_since_reset) + "\n")
+    
+    print("consolidation completed successfully.\n")
+
+def is_valid_input_CSV(csvPath):
+    """ Analyzes the first line in the given csv path and checks to see if 
+    it is in the expected format.
+    """
+    csv_line_regex = r"^\d+,\d+\.\d+,\d+\.\d+$"
+    with open(csvPath) as input:
+        first_line = input.readline()
+        if re.match(csv_line_regex, first_line):
+            return True
+    return False
+
+if len(sys.argv) != 3:
+    print("Incorrect command line arguments. The correct format is " + \
+          "\"python3 [csvPath] [outputFile]\"")
+elif not is_valid_input_CSV(sys.argv[1]):
+    print("Input file is not in the format [timestamp],[price],[volume]. Make " \
+          + "sure that the CSV file was downloaded from " \
+          + "https://api.bitcoincharts.com/v1/csv/ and try again")
+else:
+    consolidateCSV(sys.argv[1], sys.argv[2])

--- a/csv_consolidator.py
+++ b/csv_consolidator.py
@@ -1,31 +1,31 @@
 import sys
 import re
 
-def consolidateCSV(csvPath, outputFile):
-    """ Takes the csv file located at csvPath that was downloaded from 
+def consolidate_CSV(csv_path, outputFile):
+    """ Takes the csv file located at csv_path that was downloaded from 
     https://api.bitcoincharts.com/v1/csv/ and consolidates the duplicate 
     timestamps into one entry with the price and volume values being the 
     average of all entries with that timestamp. It is required that the 
-    csv file located at csvPath has the form: 
+    csv file located at csv_path has the form: 
         [timestamp], [price], [volume]
     """
-    print("beginning consolidation of " + csvPath + " to output file " + \
+    print("beginning consolidation of " + csv_path + " to output file " + \
           outputFile + "...\nthis may take a while...\n")
 
-    with open(csvPath) as input:
-        firstLine = input.readline().split(",")
-        currentTimeStamp = firstLine[0]
-        price_sum = float(firstLine[1])
-        volume_sum = float(firstLine[2])
+    with open(csv_path) as input:
+        first_line = input.readline().split(",")
+        current_time_stamp = first_line[0]
+        price_sum = float(first_line[1])
+        volume_sum = float(first_line[2])
         with open(outputFile, "w") as output:
             n_lines_since_reset = 1
             for i in input:
                 current_line = i.split(",")
-                if current_line[0] != currentTimeStamp:
-                    output.write(currentTimeStamp + "," \
+                if current_line[0] != current_time_stamp:
+                    output.write(current_time_stamp + "," \
                                  + str(price_sum / n_lines_since_reset) + "," \
                                  + str(volume_sum / n_lines_since_reset) + "\n")
-                    currentTimeStamp = current_line[0]
+                    current_time_stamp = current_line[0]
                     price_sum = float(current_line[1])
                     volume_sum = float(current_line[2])
                     n_lines_since_reset = 1
@@ -33,18 +33,18 @@ def consolidateCSV(csvPath, outputFile):
                     price_sum += float(current_line[1])
                     volume_sum += float(current_line[2])
                     n_lines_since_reset += 1
-            output.write(currentTimeStamp + "," \
+            output.write(current_time_stamp + "," \
                          + str(price_sum / n_lines_since_reset) + "," \
                          + str(volume_sum / n_lines_since_reset) + "\n")
     
     print("consolidation completed successfully.\n")
 
-def is_valid_input_CSV(csvPath):
+def is_valid_input_CSV(csv_path):
     """ Analyzes the first line in the given csv path and checks to see if 
     it is in the expected format.
     """
     csv_line_regex = r"^\d+,\d+\.\d+,\d+\.\d+$"
-    with open(csvPath) as input:
+    with open(csv_path) as input:
         first_line = input.readline()
         if re.match(csv_line_regex, first_line):
             return True
@@ -52,10 +52,10 @@ def is_valid_input_CSV(csvPath):
 
 if len(sys.argv) != 3:
     print("Incorrect command line arguments. The correct format is " + \
-          "\"python3 [csvPath] [outputFile]\"")
+          "\"python3 [csv_path] [outputFile]\"")
 elif not is_valid_input_CSV(sys.argv[1]):
     print("Input file is not in the format [timestamp],[price],[volume]. Make " \
           + "sure that the CSV file was downloaded from " \
           + "https://api.bitcoincharts.com/v1/csv/ and try again")
 else:
-    consolidateCSV(sys.argv[1], sys.argv[2])
+    consolidate_CSV(sys.argv[1], sys.argv[2])

--- a/test_csv_consolidator.py
+++ b/test_csv_consolidator.py
@@ -1,21 +1,20 @@
 import unittest
 import os
-import time
 import csv_consolidator
 
 class TestCsvConsolidator(unittest.TestCase):
 
-    def test_consolidateCSV(self):    
+    def test_consolidate_CSV(self):    
         with open("test.csv", "w") as output:
             output.write("1,20.0,20.0\n1,30.0,30.0")
-        csv_consolidator.consolidateCSV("test.csv", "testout.csv")
+        csv_consolidator.consolidate_CSV("test.csv", "testout.csv")
         with open("testout.csv") as input:
             first_line = input.readline()
         os.remove("test.csv")
         os.remove("testout.csv")
         self.assertEqual("1,25.0,25.0\n", str(first_line))
 
-    def test_incorrect_csv_format(self):
+    def test_incorrect_CSV_format(self):
         with open("test_incorrect_csv.csv", "w") as output:
             output.write("1,20,20")
         self.assertFalse(csv_consolidator.is_valid_input_CSV("test_incorrect_csv.csv"))

--- a/test_csv_consolidator.py
+++ b/test_csv_consolidator.py
@@ -1,0 +1,23 @@
+import unittest
+import os
+import time
+import csv_consolidator
+
+class TestCsvConsolidator(unittest.TestCase):
+
+    def test_consolidateCSV(self):    
+        with open("test.csv", "w") as output:
+            output.write("1,20.0,20.0\n1,30.0,30.0")
+        csv_consolidator.consolidateCSV("test.csv", "testout.csv")
+        with open("testout.csv") as input:
+            first_line = input.readline()
+        os.remove("test.csv")
+        os.remove("testout.csv")
+        self.assertEqual("1,25.0,25.0\n", str(first_line))
+
+    def test_incorrect_csv_format(self):
+        with open("test_incorrect_csv.csv", "w") as output:
+            output.write("1,20,20")
+        self.assertFalse(csv_consolidator.is_valid_input_CSV("test_incorrect_csv.csv"))
+        os.remove("test_incorrect_csv.csv")
+

--- a/test_csv_consolidator.py
+++ b/test_csv_consolidator.py
@@ -2,7 +2,7 @@ import unittest
 import os
 import csv_consolidator
 
-class TestCsvConsolidator(unittest.TestCase):
+class test_csv_consolidator(unittest.TestCase):
 
     def test_consolidate_CSV(self):    
         with open("test.csv", "w") as output:


### PR DESCRIPTION
I didn't know if we should have a folder for this script or how we should organize these files, so I'm interested in any feedback any of you may have.

Basically this script allows you to easily take a raw csv file that's downloaded from [https://api.bitcoincharts.com/v1/csv/](https://api.bitcoincharts.com/v1/csv/) and consolidate all the duplicate timestamps into single entries with the average values for both the price and the volume. I imagine that this data would be easier to work with and greatly shrinks the size of the file we're dealing with without losing much information.

I spent some time trying to figure out how to download the large files using python and wasn't having a lot of luck. When I was able to download the file, the transfer speed was so slow that it wasn't really a good solution.

There is some opportunity to add some functionality here like adding the ability to process `.gz` files directly or download files straight from that website. Sooo if you're looking for something to do, this might be a good place to start.

In the mean time, I look forward to your feedback. You won't hurt my feelings ;)